### PR TITLE
Made variable oled global and accessable by other source files

### DIFF
--- a/include/oledDisplay.hpp
+++ b/include/oledDisplay.hpp
@@ -21,8 +21,8 @@ to SSD1309 OLED display ports ----------- */
 /* ----------- Change to edit timer delay ----------- */
 #define DISPLAY_UPDATE_TIME 500
 
-static Adafruit_SSD1306 oled(SCREEN_WIDTH, SCREEN_HEIGHT,
-  OLED_MOSI, OLED_CLK, OLED_DC, OLED_RESET, OLED_CS);
+// Declares the object
+extern Adafruit_SSD1306 oled;
 
 /* ----------- Test data ----------- */
 static int speed[] = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};

--- a/src/oledDisplay.cpp
+++ b/src/oledDisplay.cpp
@@ -1,5 +1,9 @@
 #include "oledDisplay.hpp"
 
+// Defines and initilizes the object
+Adafruit_SSD1306 oled(SCREEN_WIDTH, SCREEN_HEIGHT,
+    OLED_MOSI, OLED_CLK, OLED_DC, OLED_RESET, OLED_CS);
+
 /**
  * @brief The function that displays the data on the screen
  * 
@@ -41,7 +45,7 @@ void init_oled_display() {
     // Makes semaphore flag binary 1 & 0
     oled_semaphore = xSemaphoreCreateBinary();
 
-    // Initial screen
+    // Initilizes display
     if(!oled.begin(SSD1306_SWITCHCAPVCC)) {
         Serial.print(F("SSD13006 allocation failed"));
         for(;;);


### PR DESCRIPTION
When global variables are to be used accross source files extern should be used in the header file to declare it since this allows other source files to reference the same definition. The object oled has been declared in oledDisplay.hpp and defined in oledDisplay.cpp.